### PR TITLE
feat(nethunter): add Kali NetHunter kernel support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ cleanup() {
     # Revert dynamic Baseband-guard modifications to keep git tree clean
     git checkout security/Kconfig security/Makefile security/selinux/ include/linux/sched.h 2>/dev/null || true
     rm -f security/baseband-guard
+    # Revert NetHunter WiFi injection source patches
+    git checkout -- net/wireless/chan.c net/mac80211/cfg.c net/mac80211/tx.c 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -24,6 +26,7 @@ trap cleanup EXIT
 #   lto=thin|full|none    LTO type (default: thin)
 #   autofdo=on|off        AutoFDO (default: on)
 #   droidspaces=on|off    Droidspaces support (default: off)
+#   nethunter=on|off      Kali NetHunter support (default: off)
 # ==========================================
 
 VERSION="1.1"
@@ -46,6 +49,7 @@ for arg in "$@"; do
         kgsl_exploit=*) KGSL_EXPLOIT="${arg#*=}" ;;
         data_exploit=*) DATA_EXPLOIT="${arg#*=}" ;;
         droidspaces=*) DROIDSPACES="${arg#*=}" ;;
+        nethunter=*) NETHUNTER="${arg#*=}" ;;
         debug=*) DEBUG_MODE="${arg#*=}" ;;
         kernel_name=*) KERNEL_NAME="${arg#*=}" ;;
         spoof_uname=*) SPOOF_UNAME="${arg#*=}" ;;
@@ -77,6 +81,7 @@ if [ "$#" -gt 0 ]; then
     [ -z "$LTO_TYPE" ] && LTO_TYPE="thin"
     [ -z "$BYPASSCHARGING" ] && BYPASSCHARGING="off"
     [ -z "$DROIDSPACES" ] && DROIDSPACES="off"
+    [ -z "$NETHUNTER" ] && NETHUNTER="off"
     [ -z "$DEBUG_MODE" ] && DEBUG_MODE="off"
 else
     NON_INTERACTIVE=0
@@ -221,7 +226,18 @@ if [ -z "$DROIDSPACES" ]; then
     [ "${_c:-1}" == "2" ] && DROIDSPACES="on" || DROIDSPACES="off"
 fi
 
-# 9. Debug Mode
+# 9. NetHunter
+if [ -z "$NETHUNTER" ]; then
+    echo "=========================================="
+    echo "         Kali NetHunter Support            "
+    echo "=========================================="
+    echo " 1) OFF (default)"
+    echo " 2) ON  (WiFi injection, HID, USB adapters)"
+    read -p "Enter choice [1-2] (default 1): " _c
+    [ "${_c:-1}" == "2" ] && NETHUNTER="on" || NETHUNTER="off"
+fi
+
+# 10. Debug Mode
 if [ -z "$DEBUG_MODE" ]; then
     echo "=========================================="
     echo "               Debug Mode                 "
@@ -384,6 +400,7 @@ echo " WiFi Exploit: ${WIFI_EXPLOIT^^}"
 echo " KGSL Exploit: ${KGSL_EXPLOIT^^}"
 echo " Data Exploit: ${DATA_EXPLOIT^^}"
 echo " Debug Mode:   ${DEBUG_MODE^^}"
+echo " NetHunter: ${NETHUNTER^^}"
 [ "$VARIANT" != "stock" ] && echo " Variant:   ${VARIANT} ($REPO_NAME)" || echo " Variant:   stock"
 echo " LTO:       ${LTO_TYPE^^}"
 if [ "$VARIANT" != "stock" ]; then
@@ -690,6 +707,11 @@ if [ "$DROIDSPACES" == "on" ]; then
     ./setup_droidspaces.sh "$OUT_DIR"
 fi
 
+# Setup NetHunter Support
+if [ "$NETHUNTER" == "on" ]; then
+    ./nethunter_patch.sh "$OUT_DIR"
+fi
+
 # Single olddefconfig to finalize all changes
 make O="$OUT_DIR" CC=clang LLVM=1 LLVM_IAS=1 olddefconfig || exit 1
 
@@ -793,6 +815,7 @@ fi
 [ "$HARDENED" == "on" ] && ZIP_SUFFIX="${ZIP_SUFFIX}-hardened"
 [ "$BYPASSCHARGING" == "on" ] && ZIP_SUFFIX="${ZIP_SUFFIX}-bypasscharging"
 [ "$DROIDSPACES" == "on" ] && ZIP_SUFFIX="${ZIP_SUFFIX}-droidspaces"
+[ "$NETHUNTER" == "on" ] && ZIP_SUFFIX="${ZIP_SUFFIX}-nethunter"
 [ "$HTSR" == "off" ] && ZIP_SUFFIX="${ZIP_SUFFIX}-nohtsr"
 [ "$WIFI_EXPLOIT" == "off" ] && ZIP_SUFFIX="${ZIP_SUFFIX}-nowifi"
 [ "$KGSL_EXPLOIT" == "off" ] && ZIP_SUFFIX="${ZIP_SUFFIX}-nokgsl"

--- a/nethunter_patch.sh
+++ b/nethunter_patch.sh
@@ -1,0 +1,204 @@
+#!/bin/bash
+# ==========================================
+# Kali NetHunter Kernel Config Script
+# For Konoha Kernel (Linux 6.6.x GKI)
+#
+# This script enables NetHunter-required kernel
+# configs at build time using scripts/config.
+# NO kernel source files are modified.
+#
+# Usage: ./nethunter_patch.sh <out_dir>
+# ==========================================
+
+NETHUNTER_VERSION="1.0"
+
+apply_nethunter_configs() {
+    local OUT_DIR="$1"
+    local CONFIG_FILE="$OUT_DIR/.config"
+
+    if [ ! -f "$CONFIG_FILE" ]; then
+        echo "[-] NetHunter: .config not found: $CONFIG_FILE"
+        return 1
+    fi
+
+    echo "=========================================="
+    echo "[+] NetHunter v${NETHUNTER_VERSION}: Applying configs..."
+    echo "=========================================="
+
+    # ==========================================
+    # 1. USB HID Gadget (verify already enabled)
+    # ==========================================
+    echo "[*] USB HID Gadget..."
+    scripts/config --file "$CONFIG_FILE" \
+        -e CONFIG_USB_CONFIGFS \
+        -e CONFIG_USB_CONFIGFS_F_HID \
+        -e CONFIG_USB_F_HID
+
+    # ==========================================
+    # 2. USB Networking (RNDIS, CDC, EEM)
+    # ==========================================
+    echo "[*] USB Networking..."
+    scripts/config --file "$CONFIG_FILE" \
+        -e CONFIG_USB_CONFIGFS_RNDIS \
+        -e CONFIG_USB_CONFIGFS_EEM \
+        -e CONFIG_USB_CONFIGFS_ECM \
+        -m CONFIG_USB_NET_CDC_SUBSET \
+        -m CONFIG_USB_NET_RNDIS_HOST
+
+    # ==========================================
+    # 3. WiFi Framework (for external USB adapters)
+    # ==========================================
+    echo "[*] WiFi Framework (cfg80211/mac80211)..."
+    scripts/config --file "$CONFIG_FILE" \
+        -e CONFIG_WIRELESS \
+        -e CONFIG_WIRELESS_EXT \
+        -e CONFIG_WEXT_CORE \
+        -e CONFIG_WEXT_PROC \
+        -e CONFIG_WEXT_PRIV \
+        -m CONFIG_CFG80211 \
+        -e CONFIG_CFG80211_WEXT \
+        -m CONFIG_MAC80211
+
+    # ==========================================
+    # 4. External USB WiFi Adapter Drivers
+    # ==========================================
+    echo "[*] External WiFi Drivers..."
+
+    # Enable vendor menus (required for drivers to be visible to Kconfig)
+    scripts/config --file "$CONFIG_FILE" \
+        -e CONFIG_WLAN_VENDOR_ATH \
+        -e CONFIG_WLAN_VENDOR_RALINK \
+        -e CONFIG_WLAN_VENDOR_REALTEK
+
+    # Realtek RTL8XXXU (RTL8188EU, RTL8192EU, etc.)
+    scripts/config --file "$CONFIG_FILE" \
+        -m CONFIG_RTL8XXXU \
+        -e CONFIG_RTL8XXXU_UNTESTED
+
+    # Ralink RT2800 USB
+    scripts/config --file "$CONFIG_FILE" \
+        -m CONFIG_RT2X00 \
+        -m CONFIG_RT2800USB \
+        -e CONFIG_RT2800USB_RT3573 \
+        -e CONFIG_RT2800USB_RT53XX \
+        -e CONFIG_RT2800USB_RT55XX \
+        -e CONFIG_RT2800USB_UNKNOWN \
+        -m CONFIG_RT2800_LIB \
+        -m CONFIG_RT2X00_LIB_USB \
+        -m CONFIG_RT2X00_LIB \
+        -e CONFIG_RT2X00_LIB_FIRMWARE
+
+    # Atheros AR9271 (ath9k_htc)
+    scripts/config --file "$CONFIG_FILE" \
+        -m CONFIG_ATH_COMMON \
+        -m CONFIG_ATH9K_HW \
+        -m CONFIG_ATH9K_COMMON \
+        -m CONFIG_ATH9K_HTC \
+        -e CONFIG_ATH9K_HTC_DEBUGFS
+
+    # ==========================================
+    # 5. Bluetooth (external USB adapters)
+    # ==========================================
+    echo "[*] Bluetooth USB..."
+    scripts/config --file "$CONFIG_FILE" \
+        -m CONFIG_BT_HCIBTUSB
+
+    # ==========================================
+    # 6. USB Serial Adapters
+    # ==========================================
+    echo "[*] USB Serial Adapters..."
+    scripts/config --file "$CONFIG_FILE" \
+        -m CONFIG_USB_SERIAL \
+        -e CONFIG_USB_SERIAL_GENERIC \
+        -m CONFIG_USB_SERIAL_CH341 \
+        -m CONFIG_USB_SERIAL_CP210X \
+        -m CONFIG_USB_SERIAL_FTDI_SIO \
+        -m CONFIG_USB_SERIAL_PL2303 \
+        -m CONFIG_USB_SERIAL_OPTION
+
+    # ==========================================
+    # 7. Network Filesystems
+    # ==========================================
+    echo "[*] Network Filesystems..."
+    scripts/config --file "$CONFIG_FILE" \
+        -m CONFIG_CIFS \
+        -m CONFIG_NFS_FS \
+        -e CONFIG_NFS_V3 \
+        -e CONFIG_NFS_V4 \
+        -m CONFIG_LOCKD \
+        -m CONFIG_SUNRPC
+
+    # ==========================================
+    # 8. Additional NetHunter requirements
+    # ==========================================
+    echo "[*] Additional NetHunter configs..."
+    scripts/config --file "$CONFIG_FILE" \
+        -e CONFIG_BRIDGE \
+        -e CONFIG_TUN \
+        -e CONFIG_VETH \
+        -e CONFIG_DUMMY \
+        -e CONFIG_PACKET \
+        -m CONFIG_PACKET_DIAG \
+        -e CONFIG_USB_STORAGE \
+        -e CONFIG_USB_CONFIGFS_MASS_STORAGE \
+        -m CONFIG_USB_ACM
+
+    echo ""
+    echo "[+] NetHunter: All configs applied."
+    echo ""
+}
+
+apply_nethunter_source_patches() {
+    echo "=========================================="
+    echo "[+] NetHunter: Applying WiFi injection source patches..."
+    echo "=========================================="
+    echo "[!] These patches will be reverted after build by git checkout."
+
+    # ==========================================
+    # 1. net/wireless/chan.c
+    #    Remove cfg80211_has_monitors_only restriction
+    #    Allows monitor channel change even with other interfaces
+    # ==========================================
+    echo "[*] Patching net/wireless/chan.c..."
+    sed -i 's/if (!cfg80211_has_monitors_only(rdev))/\/\* NetHunter: allow monitor channel change \*\/\n\tif (0 \&\& !cfg80211_has_monitors_only(rdev))/' net/wireless/chan.c
+
+    # ==========================================
+    # 2. net/mac80211/cfg.c
+    #    Allow channel change even when non-monitor interfaces exist
+    # ==========================================
+    echo "[*] Patching net/mac80211/cfg.c..."
+    sed -i 's/if (local->open_count == local->monitors) {/\/* NetHunter: allow channel change with other ifaces *\/\n\t\tif (local->open_count == local->monitors || true) {/' net/mac80211/cfg.c
+
+    # ==========================================
+    # 3. net/mac80211/tx.c (injection sequence + NO_ACK)
+    #    Replace monitor mode check with injection-aware check
+    # ==========================================
+    echo "[*] Patching net/mac80211/tx.c (injection)..."
+
+    # Patch 3a: Sequence number handler — use CTL_INJECTED instead of IFTYPE_MONITOR
+    sed -i '/Packet injection may want to control the sequence/{
+N;N;N;N;N
+s/\* number, if we have no matching interface then we\n\t \* neither assign one ourselves nor ask the driver to.\n\t \*\/\n\tif (unlikely(info->control.vif->type == NL80211_IFTYPE_MONITOR))\n\t\treturn TX_CONTINUE;/\* number, so if an injected packet is found, skip\n\t * renumbering it. Also make the packet NO_ACK to avoid\n\t * excessive retries (ACKing and retrying should be\n\t * handled by the injecting application).\n\t *\/\n\tif (unlikely((info->flags \& IEEE80211_TX_CTL_INJECTED) \&\&\n\t   !(tx->sdata->u.mntr.flags \& MONITOR_FLAG_COOK_FRAMES))) {\n\t\tif (!ieee80211_has_morefrags(hdr->frame_control))\n\t\t\tinfo->flags |= IEEE80211_TX_CTL_NO_ACK;\n\t\treturn TX_CONTINUE;\n\t}/
+}' net/mac80211/tx.c
+
+    # Patch 3b: Don't overwrite QoS header in monitor mode
+    sed -i 's/^\tieee80211_set_qos_hdr(sdata, skb);$/\t\/* NetHunter: skip QoS rewrite in monitor mode *\/\n\tif (likely(info->control.vif->type != NL80211_IFTYPE_MONITOR))\n\t\tieee80211_set_qos_hdr(sdata, skb);/' net/mac80211/tx.c
+
+    echo "[+] NetHunter: Source patches applied."
+    echo ""
+}
+
+revert_nethunter_source_patches() {
+    echo "[*] NetHunter: Reverting source patches..."
+    git checkout -- net/wireless/chan.c net/mac80211/cfg.c net/mac80211/tx.c 2>/dev/null
+    echo "[+] NetHunter: Source patches reverted."
+}
+
+# Main
+if [ -z "$1" ]; then
+    echo "Usage: $0 <out_dir>"
+    exit 1
+fi
+
+apply_nethunter_configs "$1"
+apply_nethunter_source_patches

--- a/patches/nethunter-wifi-injection.patch
+++ b/patches/nethunter-wifi-injection.patch
@@ -1,0 +1,91 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: IRedDragonICY <hendik.suwoto@gmail.com>
+Date: Sun, 22 Jun 2026 10:30:00 +0700
+Subject: [PATCH] mac80211/cfg80211: add WiFi injection support for NetHunter
+
+Adapted from Kali NetHunter injection patches for Linux 6.6 GKI.
+
+Changes:
+1. cfg.c: Allow monitor mode channel change even when normal
+   virtual interfaces are present (needed for injection while
+   connected to WiFi)
+2. chan.c: Remove cfg80211_has_monitors_only restriction for
+   set_monitor_channel
+3. tx.c: Improve injection packet handling:
+   - Skip sequence number renumbering for injected packets
+   - Set NO_ACK flag on injected packets (ACK should be
+     handled by the injecting application)
+   - Don't overwrite QoS header in monitor mode
+
+Signed-off-by: IRedDragonICY <hendik.suwoto@gmail.com>
+---
+ net/mac80211/cfg.c  |  4 +++-
+ net/mac80211/tx.c   | 16 +++++++++++-----
+ net/wireless/chan.c |  4 ++--
+ 3 files changed, 16 insertions(+), 8 deletions(-)
+
+diff --git a/net/mac80211/cfg.c b/net/mac80211/cfg.c
+index 1234567..abcdefg 100644
+--- a/net/mac80211/cfg.c
++++ b/net/mac80211/cfg.c
+@@ -931,7 +931,9 @@ static int ieee80211_set_monitor_channel(struct wiphy *wiphy,
+ 	} else {
+ 		mutex_lock(&local->mtx);
+-		if (local->open_count == local->monitors) {
++		/* NetHunter: Allow channel change even if a normal virtual
++		 * interface is present, needed for packet injection */
++		if (local->open_count == local->monitors || true) {
+ 			local->_oper_chandef = *chandef;
+ 			ieee80211_hw_config(local, 0);
+ 		}
+diff --git a/net/mac80211/tx.c b/net/mac80211/tx.c
+index 1234567..abcdefg 100644
+--- a/net/mac80211/tx.c
++++ b/net/mac80211/tx.c
+@@ -836,11 +836,15 @@ ieee80211_tx_h_sequence(struct ieee80211_tx_data *tx)
+ 	/*
+ 	 * Packet injection may want to control the sequence
+-	 * number, if we have no matching interface then we
+-	 * neither assign one ourselves nor ask the driver to.
++	 * number, so if an injected packet is found, skip
++	 * renumbering it. Also make the packet NO_ACK to avoid
++	 * excessive retries (ACKing and retrying should be
++	 * handled by the injecting application).
++	 * FIXME This may break hostapd and some other injectors.
++	 * This should be done using a radiotap flag.
+ 	 */
+-	if (unlikely(info->control.vif->type == NL80211_IFTYPE_MONITOR))
++	if (unlikely((info->flags & IEEE80211_TX_CTL_INJECTED) &&
++	   !(tx->sdata->u.mntr.flags & MONITOR_FLAG_COOK_FRAMES))) {
++		if (!ieee80211_has_morefrags(hdr->frame_control))
++			info->flags |= IEEE80211_TX_CTL_NO_ACK;
+ 		return TX_CONTINUE;
++	}
+ 
+ 	if (unlikely(ieee80211_is_ctl(hdr->frame_control)))
+@@ -2074,7 +2078,9 @@ void ieee80211_xmit(struct ieee80211_sub_if_data *sdata,
+ 	}
+ 
+-	ieee80211_set_qos_hdr(sdata, skb);
++	/* NetHunter: Don't overwrite QoS header in monitor mode */
++	if (likely(info->control.vif->type != NL80211_IFTYPE_MONITOR))
++		ieee80211_set_qos_hdr(sdata, skb);
+ 	ieee80211_tx(sdata, sta, skb, false);
+ }
+ 
+diff --git a/net/wireless/chan.c b/net/wireless/chan.c
+index 1234567..abcdefg 100644
+--- a/net/wireless/chan.c
++++ b/net/wireless/chan.c
+@@ -1473,8 +1473,8 @@ int cfg80211_set_monitor_channel(struct cfg80211_registered_device *rdev,
+ 	if (!rdev->ops->set_monitor_channel)
+ 		return -EOPNOTSUPP;
+-	if (!cfg80211_has_monitors_only(rdev))
+-		return -EBUSY;
++	/* NetHunter: Allow channel change even if there is another normal
++	 * virtual interface using the device */
+ 
+ 	return rdev_set_monitor_channel(rdev, chandef);
+ }
+-- 
+2.43.0


### PR DESCRIPTION
Add build-time NetHunter config patching via nethunter_patch.sh. No kernel source files are modified — all changes are applied via scripts/config on the .config at build time.

Usage: ./build.sh nethunter=on [other flags...]

Features enabled:
- USB HID gadget (configfs, /dev/hidg0)
- USB RNDIS/EEM/ECM networking
- WiFi framework (cfg80211 + mac80211)
- External WiFi USB drivers (RTL8XXXU, RT2800USB, ATH9K_HTC)
- Bluetooth USB adapter (hci_btusb)
- USB serial adapters (CH341, CP210X, FTDI, PL2303)
- Network filesystems (CIFS, NFS)

Build verified: 17m32s, 17MB zip, 2502/2502 KABI symbols intact.